### PR TITLE
Standardize the HttpClient usage

### DIFF
--- a/B2CGraphClient/B2CGraphClient.cs
+++ b/B2CGraphClient/B2CGraphClient.cs
@@ -1,13 +1,13 @@
-﻿using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+using Newtonsoft.Json;
 
 namespace B2CGraphShell
 {
@@ -27,8 +27,8 @@ namespace B2CGraphShell
             this.clientSecret = clientSecret;
             this.tenant = tenant;
 
-            // The AuthenticationContext is ADAL's primary class, in which you indicate the direcotry to use.
-            this.authContext = new AuthenticationContext("https://login.microsoftonline.com/" + tenant);
+            // The AuthenticationContext is ADAL's primary class, in which you indicate the directory to use.
+            this.authContext = new AuthenticationContext(Globals.aadInstance + tenant);
 
             // The ClientCredential is where you pass in your client_id and client_secret, which are 
             // provided to Azure AD in order to receive an access_token using the app's identity.
@@ -82,85 +82,57 @@ namespace B2CGraphShell
 
         private async Task<string> SendGraphDeleteRequest(string api)
         {
-            // NOTE: This client uses ADAL v2, not ADAL v4
-            AuthenticationResult result = authContext.AcquireToken(Globals.aadGraphResourceId, credential);
-            HttpClient http = new HttpClient();
-            string url = Globals.aadGraphEndpoint + tenant + api + "?" + Globals.aadGraphVersion;
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Delete, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", result.AccessToken);
-            HttpResponseMessage response = await http.SendAsync(request);
-
-            Console.ForegroundColor = ConsoleColor.Cyan;
-            Console.WriteLine("DELETE " + url);
-            Console.WriteLine("Authorization: Bearer " + result.AccessToken.Substring(0, 80) + "...");
-            Console.WriteLine("");
-
-            if (!response.IsSuccessStatusCode)
-            {
-                string error = await response.Content.ReadAsStringAsync();
-                object formatted = JsonConvert.DeserializeObject(error);
-                throw new WebException("Error Calling the Graph API: \n" + JsonConvert.SerializeObject(formatted, Formatting.Indented));
-            }
-
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine((int)response.StatusCode + ": " + response.ReasonPhrase);
-            Console.WriteLine("");
-
-            return await response.Content.ReadAsStringAsync();
+            return await SendRequest(HttpMethod.Delete, api);
         }
 
         private async Task<string> SendGraphPatchRequest(string api, string json)
         {
-            // NOTE: This client uses ADAL v2, not ADAL v4
-            AuthenticationResult result = authContext.AcquireToken(Globals.aadGraphResourceId, credential);
-            HttpClient http = new HttpClient();
-            string url = Globals.aadGraphEndpoint + tenant + api + "?" + Globals.aadGraphVersion;
-
-            Console.ForegroundColor = ConsoleColor.Cyan;
-            Console.WriteLine("PATCH " + url);
-            Console.WriteLine("Authorization: Bearer " + result.AccessToken.Substring(0, 80) + "...");
-            Console.WriteLine("Content-Type: application/json");
-            Console.WriteLine("");
-            Console.WriteLine(json);
-            Console.WriteLine("");
-
-            HttpRequestMessage request = new HttpRequestMessage(new HttpMethod("PATCH"), url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", result.AccessToken);
-            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-            HttpResponseMessage response = await http.SendAsync(request);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                string error = await response.Content.ReadAsStringAsync();
-                object formatted = JsonConvert.DeserializeObject(error);
-                throw new WebException("Error Calling the Graph API: \n" + JsonConvert.SerializeObject(formatted, Formatting.Indented));
-            }
-
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine((int)response.StatusCode + ": " + response.ReasonPhrase);
-            Console.WriteLine("");
-
-            return await response.Content.ReadAsStringAsync();
+            return await SendRequest(new HttpMethod("PATCH"), api, null, json);
         }
 
         private async Task<string> SendGraphPostRequest(string api, string json)
         {
+            return await SendRequest(HttpMethod.Post, api, null, json);
+        }
+
+        public async Task<string> SendGraphGetRequest(string api, string query)
+        {
+            return await SendRequest(HttpMethod.Get, api, query);
+        }
+
+        private async Task<string> SendRequest(HttpMethod method, string api, string query = null, string json = null)
+        {
             // NOTE: This client uses ADAL v2, not ADAL v4
-            AuthenticationResult result = authContext.AcquireToken(Globals.aadGraphResourceId, credential);
             HttpClient http = new HttpClient();
             string url = Globals.aadGraphEndpoint + tenant + api + "?" + Globals.aadGraphVersion;
+            if (!string.IsNullOrEmpty(query))
+            {
+                url += "&" + query;
+            }
+
+            // TODO: Do some lazy caching - track token expiry etc
+            AuthenticationResult authenticationResult = await authContext.AcquireTokenAsync(Globals.aadGraphResourceId, credential);
+            var token = authenticationResult.AccessToken;
 
             Console.ForegroundColor = ConsoleColor.Cyan;
-            Console.WriteLine("POST " + url);
-            Console.WriteLine("Authorization: Bearer " + result.AccessToken.Substring(0, 80) + "...");
-            Console.WriteLine("Content-Type: application/json");
-            Console.WriteLine("");
-            Console.WriteLine(json);
+            Console.WriteLine(method.Method + " " + url);
+            Console.WriteLine("Authorization: Bearer " + token.Substring(0, 80) + "...");
+            if (!string.IsNullOrEmpty(json))
+            {
+                Console.WriteLine("Content-Type: application/json");
+                Console.WriteLine("");
+                Console.WriteLine(json);
+            }
             Console.WriteLine("");
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", result.AccessToken);
-            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            // Append the access token for the Graph API to the Authorization header of the request, using the Bearer scheme.
+            HttpRequestMessage request = new HttpRequestMessage(method, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            if (!string.IsNullOrEmpty(json))
+            {
+                request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            }
+
             HttpResponseMessage response = await http.SendAsync(request);
 
             if (!response.IsSuccessStatusCode)
@@ -176,43 +148,5 @@ namespace B2CGraphShell
 
             return await response.Content.ReadAsStringAsync();
         }
-
-        public async Task<string> SendGraphGetRequest(string api, string query)
-        {
-            // First, use ADAL to acquire a token using the app's identity (the credential)
-            // The first parameter is the resource we want an access_token for; in this case, the Graph API.
-            AuthenticationResult result = authContext.AcquireToken("https://graph.windows.net", credential);
-            
-            // For B2C user managment, be sure to use the 1.6 Graph API version.
-            HttpClient http = new HttpClient();
-            string url = "https://graph.windows.net/" + tenant + api + "?" + "api-version=1.6";
-            if (!string.IsNullOrEmpty(query))
-            {
-                url += "&" + query;
-            } 
-
-            Console.ForegroundColor = ConsoleColor.Cyan;
-            Console.WriteLine("GET " + url);
-            Console.WriteLine("Authorization: Bearer " + result.AccessToken.Substring(0, 80) + "...");
-            Console.WriteLine("");
-
-            // Append the access token for the Graph API to the Authorization header of the request, using the Bearer scheme.
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", result.AccessToken);
-            HttpResponseMessage response = await http.SendAsync(request);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                string error = await response.Content.ReadAsStringAsync();
-                object formatted = JsonConvert.DeserializeObject(error);
-                throw new WebException("Error Calling the Graph API: \n" + JsonConvert.SerializeObject(formatted, Formatting.Indented));
-            }
-
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine((int)response.StatusCode + ": " + response.ReasonPhrase);
-            Console.WriteLine("");
-
-            return await response.Content.ReadAsStringAsync();
-        } 
     }
 }


### PR DESCRIPTION
Lifts the common code out into SendRequest and uses the defined Globals consistently for endpoints, versioning etc
