### PR TITLE
B2CExtensionApplication name change in Azure

### DIFF
--- a/B2CGraphClient/Program.cs
+++ b/B2CGraphClient/Program.cs
@@ -161,7 +161,7 @@ namespace B2CGraphShell
 
         private static void GetB2CExtensionApplication(string[] args)
         {
-            object formatted = JsonConvert.DeserializeObject(client.GetApplications("$filter=displayName eq 'b2c-extensions-app'").Result);
+            object formatted = JsonConvert.DeserializeObject(client.GetApplications("$filter=startswith(displayName, 'b2c-extensions-app')").Result);
             Console.ForegroundColor = ConsoleColor.White;
             Console.WriteLine(JsonConvert.SerializeObject(formatted, Formatting.Indented));
         }


### PR DESCRIPTION
The extension application seems to have changed it's name in the portal to:

`b2c-extensions-app. do not modify. used by aadb2c for storing user data.`

The existing code in GetB2CExtensionApplication looked for an exact name match.  This has been changed to do a "startsWith" search on b2c-extensions-app.